### PR TITLE
Update mongoose version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Tyler Hughes <iampbt@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "mongoose": "^3.8.19"
+    "mongoose": "^4.4.19"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
We were unable to get hapi-goose working on our project without upgrading the mongoose dependency. This seems to fix issues we were having with `cannot find module 'mongodb/node_modules/bson'` error.
